### PR TITLE
Facilitate Insecure TLS Connections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/CUCyber/ja3transport
+module github.com/Ne0nd0g/ja3transport
 
 go 1.13
 

--- a/ja3client.go
+++ b/ja3client.go
@@ -27,6 +27,17 @@ func New(b Browser) (*JA3Client, error) {
 	return client, nil
 }
 
+// New creates a JA3Client based on a Browser struct
+// The transport allows an insecure TLS connection by setting InsecureSkipVerify to true
+func NewInsecure(b Browser) (*JA3Client, error) {
+	client, err := NewWithStringInsecure(b.JA3)
+	if err != nil {
+		return nil, err
+	}
+	client.Browser = b
+	return client, nil
+}
+
 // NewWithString creates a JA3 client with the specified JA3 string
 func NewWithString(ja3 string) (*JA3Client, error) {
 	tr, err := NewTransport(ja3)
@@ -39,6 +50,24 @@ func NewWithString(ja3 string) (*JA3Client, error) {
 	return &JA3Client{
 		client,
 		&tls.Config{},
+		Browser{JA3: ja3},
+	}, nil
+}
+
+// NewWithString creates a JA3 client with the specified JA3 string
+// The transport allows an insecure TLS connection by setting InsecureSkipVerify to true
+// This is set in both the JA3 client and Config objects
+func NewWithStringInsecure(ja3 string) (*JA3Client, error) {
+	tr, err := NewTransportInsecure(ja3)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Transport: tr}
+
+	return &JA3Client{
+		client,
+		&tls.Config{InsecureSkipVerify: true},
 		Browser{JA3: ja3},
 	}, nil
 }

--- a/transport.go
+++ b/transport.go
@@ -79,6 +79,12 @@ func NewTransport(ja3 string) (*http.Transport, error) {
 	return NewTransportWithConfig(ja3, &tls.Config{})
 }
 
+// NewTransport creates an http.Transport which mocks the given JA3 signature when HTTPS is used
+// The transport allows an insecure TLS connection by setting InsecureSkipVerify to true
+func NewTransportInsecure(ja3 string) (*http.Transport, error) {
+	return NewTransportWithConfig(ja3, &tls.Config{InsecureSkipVerify: true})
+}
+
 // NewTransportWithConfig creates an http.Transport object given a utls.Config
 func NewTransportWithConfig(ja3 string, config *tls.Config) (*http.Transport, error) {
 	spec, err := stringToSpec(ja3)


### PR DESCRIPTION
Add `NewInsecure`,`NewWithStringInsecure`, and `NewTransportInsecure` functions so the returned client will accept untrusted TLS connections. This is useful for when you want to interact with a server using self-signed X.509 certificates.

The other alternative is to import the `github.com/refraction-networking/utls` library, build a `utls.Config` structure with `InsecureSkipVerify = true`, call the existing `NewTransportWithConfig()` function with the previously created utls.Config, call `NewWithString()` function, and update the returned `JA3Client.Config` struct to allow insecure connections.

The InsecureSkipVerify must be set in two places. Once on the exported JA3Client.Config and a second time on the private (not exported) JA3Client.client (a *http.Client).